### PR TITLE
Update to newest epel-release for EL7

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@ epel_release:
   "4": 10
   "5": 4
   "6": 8
-  "7": 1
+  "7": 2
 
 epel_repo_url: "http://download.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{{ ansible_userspace_architecture }}{{ '/' if ansible_distribution_major_version < '7' else '/e/' }}epel-release-{{ ansible_distribution_major_version }}-{{ epel_release[ansible_distribution_major_version] }}.noarch.rpm"
 epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"


### PR DESCRIPTION
Maybe we should look into doing something like this:
- https://stackoverflow.com/questions/14016286/how-to-programmatically-install-the-latest-epel-release-rpm-without-knowing-its
- https://github.com/zigg/octothorpe/commit/c3b0cdf751a6818385925c7b358361e000076daf
