### PR TITLE
Don't install repo if it is already installed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+epel_repofile_path: "/etc/yum.repos.d/epel.repo"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check for existing EPEL repo
   stat: path=/etc/yum.repos.d/epel.repo
-  register: repofile
+  register: epel_repofile
 
 - name: Install EPEL repo.
   yum:
@@ -11,10 +11,10 @@
   until: '"failed" not in result'
   retries: 5
   delay: 10
-  when: repofile is not defined
+  when: epel_repofile.exists == False
 
 - name: Import EPEL GPG key.
   rpm_key:
     key: "{{ epel_repo_gpg_key_url }}"
     state: present
-  when: repofile is not defined
+  when: epel_repofile.exists == False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check for existing EPEL repo
-  stat: path=/etc/yum.repos.d/epel.repo
+  stat: path={{ epel_repofile_path }}
   register: epel_repofile
 
 - name: Install EPEL repo.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Check for existing EPEL repo
+  stat: path=/etc/yum.repos.d/epel.repo
+  register: repofile
+
 - name: Install EPEL repo.
   yum:
     name: "{{ epel_repo_url }}"
@@ -7,8 +11,10 @@
   until: '"failed" not in result'
   retries: 5
   delay: 10
+  when: repofile is not defined
 
 - name: Import EPEL GPG key.
   rpm_key:
     key: "{{ epel_repo_gpg_key_url }}"
     state: present
+  when: repofile is not defined


### PR DESCRIPTION
Hi!

Amazon Linux is a RHEL derivative used in AWS.  Sounds like it forked at RHEL 5, but contains many packages of RHEL 6 at the moment.  Unfortunately, this role fails on it today.  This PR should address that.

Details:

Ansible returns 'NA' for ansible_distribution_major_version (understandably), and so this fails in `defaults/main.yml`:

```yml
  epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
  epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
```

That said, Ansible Linux comes with EPEL pre-installed (just disabled by default), so this changes the check to verify whether the epel.repo file exists and skip the installation entirely if it's there.  

This may be better behavior regardless for follow-up runs of the same role.

Take a look and let me know what you think!
