### PR TITLE
Don't error GPG import in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,3 +18,4 @@
     key: "{{ epel_repo_gpg_key_url }}"
     state: present
   when: not epel_repofile_result.stat.exists
+  ignore_errors: "{{ ansible_check_mode }}"


### PR DESCRIPTION
We use this role in our prod environment, we often do check runs prior to rolling out changes when any of our roles reference this one as a dependency our check fails