### PR TITLE
Allow nonroot user to execute

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,11 +11,13 @@
   until: '"failed" not in result'
   retries: 5
   delay: 10
+  become: "{{ epel_nonroot }}"
   when: not epel_repofile_result.stat.exists
 
 - name: Import EPEL GPG key.
   rpm_key:
     key: "{{ epel_repo_gpg_key_url }}"
     state: present
+  become: "{{ epel_nonroot }}"
   when: not epel_repofile_result.stat.exists
   ignore_errors: "{{ ansible_check_mode }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+epel_nonroot: "{{ (ansible_env.USER is undefined) | ternary(ansible_env.HOME != '/root', ansible_env.USER != 'root') }}"


### PR DESCRIPTION
This PR resolves the problem that if the remote user is not root he can't execute this role due to permission error.
This PR adds the variable "epel_nonroot", whose value is true if the remote user is not root and otherwise false,
and sets `become: "{{ epel_nonroot }}"` to tasks which need root priviledges.