### PR TITLE
Fix #23

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
     name: "{{ epel_repo_url }}"
     state: present
   register: result
-  until: '"failed" not in result'
+  until: 'result.rc == 0'
   retries: 5
   delay: 10
   when: not epel_repofile_result.stat.exists


### PR DESCRIPTION
The role appeared to fail in a non-idempotent way due to task `"failed": true` being set, even when `yum` package was already installed and it should just continue.

Looks like checking return code `!= 0` is better in this case, as it's correctly set to `0` when `yum` says it's already installed.

Error was:

      TASK [geerlingguy.repo-epel : Install EPEL repo.] ******************************
      task path: /tmp/kitchen/roles/geerlingguy.repo-epel/tasks/main.yml:6
      FAILED - RETRYING: Install EPEL repo. (5 retries left).
      FAILED - RETRYING: Install EPEL repo. (4 retries left).
      FAILED - RETRYING: Install EPEL repo. (3 retries left).
      FAILED - RETRYING: Install EPEL repo. (2 retries left).
      FAILED - RETRYING: Install EPEL repo. (1 retries left).
      fatal: [localhost]: FAILED! => {"attempts": 5, "changed": false, "failed": true, "msg": "", "rc": 0, "results": ["epel-release-7-11.noarch providing /tmp/epel-release-latest-7.noarch9yXbfu.rpm is already installed"]}
      to retry, use: --limit @/tmp/kitchen/default.retry

      PLAY RECAP *********************************************************************
      localhost                  : ok=2    changed=0    unreachable=0    failed=1