### PR TITLE
Improve tests

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,9 @@
+---
+- name: Prepare test container
+  hosts: all
+
+  tasks:
+    - name: Ensure epel-release package is absent
+      package:
+        name: epel-release
+        state: absent

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -6,9 +6,19 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_hosts_file(host):
-    f = host.file('/etc/hosts')
+def test_epel_repo_file_should_exist(host):
+    epel_repo_file = host.file('/etc/yum.repos.d/epel.repo')
 
-    assert f.exists
-    assert f.user == 'root'
-    assert f.group == 'root'
+    assert epel_repo_file.exists
+
+
+def test_yum_should_install_packages_in_epel_repo(host):
+    yum_install_return_code = host.run('yum install -y htop').rc
+
+    assert yum_install_return_code == 0
+
+
+def test_installed_package_should_run(host):
+    htop_return_code = host.run('htop --version').rc
+
+    assert htop_return_code == 0


### PR DESCRIPTION
As noted in #28, the current test suite runs on an image that already has `epel-release` installed.

This PR removes the `epel-release` package before testing and adds tests to make sure the role installs a package from EPEL and can run the installed package.

Hopefully you find this small improvement useful. Thanks very much for your consideration and your contributions to the Ansible ecosystem!