### PR TITLE
Import GPG key before installing the repo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,13 @@
   stat: path={{ epel_repofile_path }}
   register: epel_repofile_result
 
+- name: Import EPEL GPG key.
+  rpm_key:
+    key: "{{ epel_repo_gpg_key_url }}"
+    state: present
+  when: not epel_repofile_result.stat.exists
+  ignore_errors: "{{ ansible_check_mode }}"
+
 - name: Install EPEL repo.
   yum:
     name: "{{ epel_repo_url }}"
@@ -12,10 +19,3 @@
   retries: 5
   delay: 10
   when: not epel_repofile_result.stat.exists
-
-- name: Import EPEL GPG key.
-  rpm_key:
-    key: "{{ epel_repo_gpg_key_url }}"
-    state: present
-  when: not epel_repofile_result.stat.exists
-  ignore_errors: "{{ ansible_check_mode }}"


### PR DESCRIPTION
The EPEL repo will fail to install if localpkg_gpgcheck is set to 1 in yum.conf because the gpg key for EPEL is not installed yet. 