### PR TITLE
switched to 'inject_facts_as_vars: false' syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This role only is needed/runs on RHEL and its derivatives.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    epel_repo_url: "http://download.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{{ ansible_userspace_architecture }}{{ '/' if ansible_distribution_major_version < '7' else '/e/' }}epel-release-{{ ansible_distribution_major_version }}-{{ epel_release[ansible_distribution_major_version] }}.noarch.rpm"
-    epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    epel_repo_url: "http://download.fedoraproject.org/pub/epel/{{ ansible_facts.distribution_major_version }}/{{ ansible_facts.userspace_architecture }}{{ '/' if ansible_facts.distribution_major_version < '7' else '/e/' }}epel-release-{{ ansible_facts.distribution_major_version }}-{{ epel_release[ansible_facts.distribution_major_version] }}.noarch.rpm"
+    epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_facts.distribution_major_version }}"
 
 The EPEL repo URL and GPG key URL. Generally, these should not be changed, but if this role is out of date, or if you need a very specific version, these can both be overridden.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts.distribution_major_version }}.noarch.rpm"
+epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_facts.distribution_major_version }}"
 epel_repofile_path: "/etc/yum.repos.d/epel.repo"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,6 +17,9 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      inject_facts_as_vars: false
   lint:
     name: ansible-lint
   playbooks:


### PR DESCRIPTION
see: https://raw.githubusercontent.com/ansible/ansible/devel/examples/ansible.cfg

```
# Ansible facts are available inside the ansible_facts.* dictionary
# namespace. This setting maintains the behaviour which was the default prior
# to 2.5, duplicating these variables into the main namespace, each with a
# prefix of 'ansible_'.
# This variable is set to True by default for backwards compatibility. It
# will be changed to a default of 'False' in a future release.
# ansible_facts.
# inject_facts_as_vars = True
```