### PR TITLE
Allow static mirror configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The EPEL repo URL and GPG key URL. Generally, these should not be changed, but if this role is out of date, or if you need a very specific version, these can both be overridden.
 
+A static mirror can be set through the `epel_mirror_url` variable (see `defaults/main.yml`):
+
+  ```yml
+  epel_mirror_url: "https://fedora.cu.be"
+  ```
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Static mirror can be set here
-#epel_mirror_url: "https://fedora.cu.be"
-epel_repo_url: "{{ epel_mirror_url |default('https://dl.fedoraproject.org/pub') }}\
-                /epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+# epel_mirror_url: "https://fedora.cu.be"
+os_version: "{{ ansible_distribution_major_version }}"
+epel_repo_url: "{{ epel_mirror_url |default('https://dl.fedoraproject.org/pub') }}/epel/epel-release-latest-{{ os_version }}.noarch.rpm"
+epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ os_version }}"
 epel_repofile_path: "/etc/yum.repos.d/epel.repo"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
-epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+# Static mirror can be set here
+#epel_mirror_url: "https://fedora.cu.be"
+epel_repo_url: "{{ epel_mirror_url |default('https://dl.fedoraproject.org/pub') }}\
+                /epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 epel_repofile_path: "/etc/yum.repos.d/epel.repo"

--- a/molecule/default/yaml-lint.yml
+++ b/molecule/default/yaml-lint.yml
@@ -1,6 +1,9 @@
 ---
 extends: default
+ignore: |
+  molecule-env
 rules:
   line-length:
     max: 140
     level: warning
+  truthy: disable

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,9 @@
   delay: 10
   when: not epel_repofile_result.stat.exists
 
+- include: mirror.yml
+  when: epel_mirror_url is defined
+
 - name: Import EPEL GPG key.
   rpm_key:
     key: "{{ epel_repo_gpg_key_url }}"

--- a/tasks/mirror.yml
+++ b/tasks/mirror.yml
@@ -1,0 +1,66 @@
+---
+
+- name: Configure static mirror for EPEL repo.
+  yum_repository:
+    file: epel
+    name: epel
+    description: "Extra Packages for Enterprise Linux {{ ansible_distribution_major_version }} - $basearch"
+    baseurl: "{{ epel_mirror_url }}/epel/{{ ansible_distribution_major_version }}/$basearch"
+    gpgcheck: yes
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    enabled: yes
+
+- name: Configure static mirror for EPEL repo (Debug).
+  yum_repository:
+    file: epel
+    name: epel-debuginfo
+    description:  "Extra Packages for Enterprise Linux {{ ansible_distribution_major_version }} - $basearch - Debug"
+    baseurl: "{{ epel_mirror_url }}/epel/{{ ansible_distribution_major_version }}/$basearch/debug"
+    gpgcheck: yes
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    enabled: no
+
+- name: Configure static mirror for EPEL repo (Source).
+  yum_repository:
+    file: epel
+    name: epel-source
+    description:  "Extra Packages for Enterprise Linux {{ ansible_distribution_major_version }} \
+                   - $basearch - Source"
+    baseurl: "{{ epel_mirror_url }}/epel/{{ ansible_distribution_major_version }}/SRPMS"
+    gpgcheck: yes
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    enabled: no
+
+- name: Configure static mirror for EPEL-Testing repo.
+  yum_repository:
+    file: epel-testing
+    name: epel-testing
+    description: "Extra Packages for Enterprise Linux {{ ansible_distribution_major_version }} \
+                  - Testing - $basearch"
+    baseurl: "{{ epel_mirror_url }}/epel/testing/{{ ansible_distribution_major_version }}/$basearch"
+    gpgcheck: yes
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    enabled: no
+
+- name: Configure static mirror for EPEL-Testing repo (Debug).
+  yum_repository:
+    file: epel-testing
+    name: epel-testing-debuginfo
+    description: "Extra Packages for Enterprise Linux {{ ansible_distribution_major_version }} \
+                  - Testing - $basearch - Debug"
+    baseurl: "{{ epel_mirror_url }}/epel/testing/{{ ansible_distribution_major_version }}/$basearch/debug"
+    gpgcheck: yes
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    enabled: no
+
+- name: Configure static mirror for EPEL-Testing repo (Source).
+  yum_repository:
+    file: epel-testing
+    name: epel-testing-source
+    description: "Extra Packages for Enterprise Linux {{ ansible_distribution_major_version }} \
+                  - Testing - $basearch - Source"
+    baseurl: "{{ epel_mirror_url }}/epel/testing/{{ ansible_distribution_major_version }}/SRPMS"
+    gpgcheck: yes
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    enabled: no
+

--- a/tasks/mirror.yml
+++ b/tasks/mirror.yml
@@ -1,66 +1,60 @@
 ---
-
 - name: Configure static mirror for EPEL repo.
   yum_repository:
     file: epel
     name: epel
-    description: "Extra Packages for Enterprise Linux {{ ansible_distribution_major_version }} - $basearch"
-    baseurl: "{{ epel_mirror_url }}/epel/{{ ansible_distribution_major_version }}/$basearch"
+    description: "Extra Packages for Enterprise Linux {{ os_version }} - $basearch"
+    baseurl: "{{ epel_mirror_url }}/epel/{{ os_version }}/$basearch"
     gpgcheck: yes
-    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ os_version }}"
     enabled: yes
 
 - name: Configure static mirror for EPEL repo (Debug).
   yum_repository:
     file: epel
     name: epel-debuginfo
-    description:  "Extra Packages for Enterprise Linux {{ ansible_distribution_major_version }} - $basearch - Debug"
-    baseurl: "{{ epel_mirror_url }}/epel/{{ ansible_distribution_major_version }}/$basearch/debug"
+    description: "Extra Packages for Enterprise Linux {{ os_version }} - $basearch - Debug"
+    baseurl: "{{ epel_mirror_url }}/epel/{{ os_version }}/$basearch/debug"
     gpgcheck: yes
-    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ os_version }}"
     enabled: no
 
 - name: Configure static mirror for EPEL repo (Source).
   yum_repository:
     file: epel
     name: epel-source
-    description:  "Extra Packages for Enterprise Linux {{ ansible_distribution_major_version }} \
-                   - $basearch - Source"
-    baseurl: "{{ epel_mirror_url }}/epel/{{ ansible_distribution_major_version }}/SRPMS"
+    description: "Extra Packages for Enterprise Linux {{ os_version }} - $basearch - Source"
+    baseurl: "{{ epel_mirror_url }}/epel/{{ os_version }}/SRPMS"
     gpgcheck: yes
-    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ os_version }}"
     enabled: no
 
 - name: Configure static mirror for EPEL-Testing repo.
   yum_repository:
     file: epel-testing
     name: epel-testing
-    description: "Extra Packages for Enterprise Linux {{ ansible_distribution_major_version }} \
-                  - Testing - $basearch"
-    baseurl: "{{ epel_mirror_url }}/epel/testing/{{ ansible_distribution_major_version }}/$basearch"
+    description: "Extra Packages for Enterprise Linux {{ os_version }} - Testing - $basearch"
+    baseurl: "{{ epel_mirror_url }}/epel/testing/{{ os_version }}/$basearch"
     gpgcheck: yes
-    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ os_version }}"
     enabled: no
 
 - name: Configure static mirror for EPEL-Testing repo (Debug).
   yum_repository:
     file: epel-testing
     name: epel-testing-debuginfo
-    description: "Extra Packages for Enterprise Linux {{ ansible_distribution_major_version }} \
-                  - Testing - $basearch - Debug"
-    baseurl: "{{ epel_mirror_url }}/epel/testing/{{ ansible_distribution_major_version }}/$basearch/debug"
+    description: "Extra Packages for Enterprise Linux {{ os_version }} - Testing - $basearch - Debug"
+    baseurl: "{{ epel_mirror_url }}/epel/testing/{{ os_version }}/$basearch/debug"
     gpgcheck: yes
-    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ os_version }}"
     enabled: no
 
 - name: Configure static mirror for EPEL-Testing repo (Source).
   yum_repository:
     file: epel-testing
     name: epel-testing-source
-    description: "Extra Packages for Enterprise Linux {{ ansible_distribution_major_version }} \
-                  - Testing - $basearch - Source"
-    baseurl: "{{ epel_mirror_url }}/epel/testing/{{ ansible_distribution_major_version }}/SRPMS"
+    description: "Extra Packages for Enterprise Linux {{ os_version }} - Testing - $basearch - Source"
+    baseurl: "{{ epel_mirror_url }}/epel/testing/{{ os_version }}/SRPMS"
     gpgcheck: yes
-    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ os_version }}"
     enabled: no
-


### PR DESCRIPTION
You need to be able to configure a static mirror under some consistences like filtered outgoing traffic.

This merge is not disruptive for system running under the current one.