### PR TITLE
Fix README & rename variables for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ This role only is needed/runs on RHEL and its derivatives.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    epel_repo_url: "http://download.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{{ ansible_userspace_architecture }}{{ '/' if ansible_distribution_major_version < '7' else '/e/' }}epel-release-{{ ansible_distribution_major_version }}-{{ epel_release[ansible_distribution_major_version] }}.noarch.rpm"
+    epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
     epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    epel_repo_file_path: "/etc/yum.repos.d/epel.repo"
 
 The EPEL repo URL and GPG key URL. Generally, these should not be changed, but if this role is out of date, or if you need a very specific version, these can both be overridden.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
-epel_repofile_path: "/etc/yum.repos.d/epel.repo"
+epel_repo_file_path: "/etc/yum.repos.d/epel.repo"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Check if EPEL repo is already configured.
   stat:
-    path: "{{ epel_repofile_path }}"
-  register: epel_repofile_result
+    path: "{{ epel_repo_file_path }}"
+  register: epel_repo_file_result
 
 - name: Install EPEL repo.
   yum:
@@ -12,11 +12,11 @@
   until: result is succeeded
   retries: 5
   delay: 10
-  when: not epel_repofile_result.stat.exists
+  when: not epel_repo_file_result.stat.exists
 
 - name: Import EPEL GPG key.
   rpm_key:
     key: "{{ epel_repo_gpg_key_url }}"
     state: present
-  when: not epel_repofile_result.stat.exists
+  when: not epel_repo_file_result.stat.exists
   ignore_errors: "{{ ansible_check_mode }}"


### PR DESCRIPTION
* Add missing default variable to README.md
* Correct default values in README.md
* Rename 'epel_repofile_path' to 'epel_repo_file_path'
* Rename 'epel_repofile_result' to 'epel_repo_file_result'