### PR TITLE
Enable PowerTools repo on CentOS 8

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,3 +20,13 @@
     state: present
   when: not epel_repofile_result.stat.exists
   ignore_errors: "{{ ansible_check_mode }}"
+
+- name: Enable PowerTools repo on CentOS 8
+  ini_file:
+    dest: /etc/yum.repos.d/CentOS-PowerTools.repo
+    section: PowerTools
+    option: enabled
+    value: 1
+  when: 
+    - ansible_distribution == "CentOS"
+    - ansible_distribution_major_version == '8'


### PR DESCRIPTION
There is much discussion on the best way to modify an existing repo. This seems like the simplest. I'll add a RHEL section if/when I have access to a RHEL 8 filesystem.