### PR TITLE
Added 'community.general' collection.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,5 @@
 ---
-dependencies:
-  - collection: community.general
+dependencies: []
 
 galaxy_info:
   role_name: repo-epel


### PR DESCRIPTION
Hi everyone. As I know, now ini_file is an external module that contains in community.general collection. So if I correctly understand, we need to use community.general.ini_file and add community.general collection requirements.