### PR TITLE
Remove spaces around repo file "enabled" option

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,4 +31,5 @@
     section: epel
     option: enabled
     value: "{{ epel_repo_disable | ternary(0, 1) }}"
+    no_extra_spaces: true
     mode: 0644


### PR DESCRIPTION
A manual install of the EPEL repo on a RHEL 8 host doesn't insert spaces around the `=` sign in the the `enabled` option under the `[epel]` section of ` /etc/yum.repos.d/epel.repo`.

```
[ec2-user@ip-172-31-20-145 ~]$ grep --color=auto -A12 '\[epel\]' /etc/yum.repos.d/epel.repo
[epel]
name=Extra Packages for Enterprise Linux 8 - $basearch
# It is much more secure to use the metalink, but if you wish to use a local mirror
# place its address here.
#baseurl=https://download.example/pub/epel/8/Everything/$basearch
metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch&infra=$infra&content=$contentdir
enabled=1
gpgcheck=1
countme=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8

[epel-debuginfo]
name=Extra Packages for Enterprise Linux 8 - $basearch - Debug
[ec2-user@ip-172-31-20-145 ~]$
```

Running the `geerlingguy.repo-epel` role against this host with `epel_repo_disable` set to `false` doesn't change whether the repo is enabled on the host. However, the `Disable Main EPEL repo.` task adds spaces around the `=` symbol in this option. This misleads the user to think the task disabled the repository.