### PR TITLE
Use 'epel_repofile_path' variable instead of hardcoding the path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ The EPEL repo URL and GPG key URL. Generally, these should not be changed, but i
 
 Set to `true` to disable the EPEL repo (even if already installed).
 
+If you already have EPEL repo installed, you may have to override the variable (i.e. in case the file is not named epel.repo)
+
+```
+epel_repofile_path: "/etc/yum.repos.d/epel.repo"
+```
+
 ## Dependencies
 
 None.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
 
 - name: Disable Main EPEL repo.
   ini_file:
-    path: "/etc/yum.repos.d/epel.repo"
+    path: "{{ epel_repofile_path }}"
     section: epel
     option: enabled
     value: "{{ epel_repo_disable | ternary(0, 1) }}"


### PR DESCRIPTION
Minor change to use the variable 'epel_repofile_path' when disabling/enabling the repo