### PR TITLE
Fix deprecation warning for ansible_facts variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This role only is needed/runs on RHEL and its derivatives.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    epel_repo_url: "http://download.fedoraproject.org/pub/epel/{{ ansible_facts.distribution_major_version }}/{{ ansible_userspace_architecture }}{{ '/' if ansible_facts.distribution_major_version < '7' else '/e/' }}epel-release-{{ ansible_facts.distribution_major_version }}-{{ epel_release[ansible_facts.distribution_major_version] }}.noarch.rpm"
-    epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_facts.distribution_major_version }}"
+    epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"
+    epel_repo_gpg_key_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_facts['distribution_major_version'] }}"
 
 The EPEL repo URL and GPG key URL. Generally, these should not be changed, but if this role is out of date, or if you need a very specific version, these can both be overridden.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts.distribution_major_version }}.noarch.rpm"
-epel_repo_gpg_key_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_facts.distribution_major_version }}"
+epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"
+epel_repo_gpg_key_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_facts['distribution_major_version'] }}"
 epel_repofile_path: "/etc/yum.repos.d/epel.repo"
 epel_repo_disable: false


### PR DESCRIPTION
Fixes deprecation warning for `ansible_facts` variables.

Example error:

```bash
TASK [geerlingguy.repo-epel : Install EPEL repo.] ************************************
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
Origin: /home/stovepipe/git-repos/development-environment/roles/geerlingguy.repo-epel/defaults/main.yml:2:16

1 ---
2 epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}....
                 ^ column 16

Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.

changed: [localhost]
```

Also updates README to reflect changes.